### PR TITLE
Missing interface for in-memory relying parties registration

### DIFF
--- a/src/IdentityServer4.WsFederation/WsFederation/WsFederationBuilderExtensions.cs
+++ b/src/IdentityServer4.WsFederation/WsFederation/WsFederationBuilderExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IIdentityServerBuilder AddInMemoryRelyingParties(this IIdentityServerBuilder builder, IEnumerable<RelyingParty> relyingParties)
         {
             builder.Services.AddSingleton(relyingParties);
-            builder.Services.AddSingleton<InMemoryRelyingPartyStore>();
+            builder.Services.AddSingleton<IRelyingPartyStore, InMemoryRelyingPartyStore>();
 
             return builder;
         }


### PR DESCRIPTION
Added missing interface to `InMemoryRelyingPartyStore` registration that was stopping the store being used